### PR TITLE
Implement sort command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_SORT_SUCCESSFUL = "Sorted successfully.";
+    public static final String MESSAGE_SORT_UNSUCCESSFUL = "Unable to sort.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -57,4 +57,8 @@ public class SortCommand extends Command {
         logger.info("SortCommand execution completed. List sorted by: " + prefix);
         return new CommandResult(MESSAGE_SORT_SUCCESSFUL);
     }
+
+    public String getSortPrefix() {
+        return prefix;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -12,6 +12,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.logging.Logger;
+
 /**
  * Represents SortCommand to sort the address book based on specified attribute and update the model
  * to reflect the new sorting order.
@@ -27,6 +29,7 @@ public class SortCommand extends Command {
             + "[" + PREFIX_ADDRESS + "] "
             + "[" + PREFIX_TAG + "] "
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME;
+    private static final Logger logger = Logger.getLogger(SortCommand.class.getName());
     private final String prefix;
 
     /**
@@ -51,6 +54,7 @@ public class SortCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.updateSortedFilteredPersonList(prefix);
+        logger.info("SortCommand execution completed. List sorted by: " + prefix);
         return new CommandResult(MESSAGE_SORT_SUCCESSFUL);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,18 +1,17 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.Messages.MESSAGE_SORT_SUCCESSFUL;
-
-import seedu.address.model.Model;
-
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.logic.Messages.MESSAGE_SORT_SUCCESSFUL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.logging.Logger;
+
+import seedu.address.model.Model;
 
 /**
  * Represents SortCommand to sort the address book based on specified attribute and update the model

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.Messages.MESSAGE_SORT_SUCCESSFUL;
+
+import seedu.address.model.Model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Represents SortCommand to sort the address book based on specified attribute and update the model
+ * to reflect the new sorting order.
+ */
+public class SortCommand extends Command {
+    public static final String COMMAND_WORD = "sort";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sort all persons by the attribute specified "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: "
+            + "[" + PREFIX_NAME + "] "
+            + "[" + PREFIX_PHONE + "] "
+            + "[" + PREFIX_EMAIL + "] "
+            + "[" + PREFIX_ADDRESS + "] "
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME;
+    private final String prefix;
+
+    /**
+     * Constructs a SortCommand to sort the address book based on specified prefix.
+     *
+     * @param prefix The prefix indicating the attribute to sort by.
+     */
+    public SortCommand(String prefix) {
+        this.prefix = prefix;
+        requireNonNull(prefix);
+    }
+
+    /**
+     * Executes sort command by updating the filtered list of persons in the model
+     * and sorting them based on the given prefix.
+     *
+     * @param model The model containing the address book data and the logic for sorting the address book.
+     * @return The result of executing the sort command, containing a success message.
+     */
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortedFilteredPersonList(prefix);
+        return new CommandResult(MESSAGE_SORT_SUCCESSFUL);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -6,7 +6,11 @@ import seedu.address.model.Model;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Represents SortCommand to sort the address book based on specified attribute and update the model
@@ -21,6 +25,7 @@ public class SortCommand extends Command {
             + "[" + PREFIX_PHONE + "] "
             + "[" + PREFIX_EMAIL + "] "
             + "[" + PREFIX_ADDRESS + "] "
+            + "[" + PREFIX_TAG + "] "
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME;
     private final String prefix;
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.commands.PinCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case PinCommand.COMMAND_WORD:
             return new PinCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -39,7 +39,7 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         default:
             logger.warning("Invalid sorting prefix provided: " + trimmedArgs);
-            throw new ParseException(String.format(MESSAGE_SORT_UNSUCCESSFUL, SortCommand.MESSAGE_USAGE));
+            throw new ParseException("Invalid prefix used.");
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -19,6 +19,8 @@ public class SortCommandParser implements Parser<SortCommand> {
             return new SortCommand(PREFIX_EMAIL.getPrefix());
         } else if (trimmedArgs.equals(PREFIX_ADDRESS.getPrefix())) {
             return new SortCommand(PREFIX_ADDRESS.getPrefix());
+        } else if (trimmedArgs.equals(PREFIX_TAG.getPrefix())) {
+            return new SortCommand(PREFIX_TAG.getPrefix());
         } else {
             throw new ParseException(String.format(MESSAGE_SORT_UNSUCCESSFUL, SortCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -10,15 +10,17 @@ public class SortCommandParser implements Parser<SortCommand> {
 
     public SortCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_SORT_UNSUCCESSFUL, SortCommand.MESSAGE_USAGE));
-        }
 
         if (trimmedArgs.equals(PREFIX_NAME.getPrefix())) {
-            System.out.println("Sorted successfully...");
             return new SortCommand(PREFIX_NAME.getPrefix());
+        } else if (trimmedArgs.equals(PREFIX_PHONE.getPrefix())) {
+            return new SortCommand(PREFIX_PHONE.getPrefix());
+        } else if (trimmedArgs.equals(PREFIX_EMAIL.getPrefix())) {
+            return new SortCommand(PREFIX_EMAIL.getPrefix());
+        } else if (trimmedArgs.equals(PREFIX_ADDRESS.getPrefix())) {
+            return new SortCommand(PREFIX_ADDRESS.getPrefix());
+        } else {
+            throw new ParseException(String.format(MESSAGE_SORT_UNSUCCESSFUL, SortCommand.MESSAGE_USAGE));
         }
-
-        return null;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.Messages.MESSAGE_SORT_UNSUCCESSFUL;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+public class SortCommandParser implements Parser<SortCommand> {
+
+    public SortCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_SORT_UNSUCCESSFUL, SortCommand.MESSAGE_USAGE));
+        }
+
+        if (trimmedArgs.equals(PREFIX_NAME.getPrefix())) {
+            System.out.println("Sorted successfully...");
+            return new SortCommand(PREFIX_NAME.getPrefix());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,9 +1,5 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.SortCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-
-import static seedu.address.logic.Messages.MESSAGE_SORT_UNSUCCESSFUL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -12,8 +8,23 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.logging.Logger;
 
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments to create a SortCommand and parsing logic identifies the sorting prefix.
+ *
+ */
 public class SortCommandParser implements Parser<SortCommand> {
     private static final Logger logger = Logger.getLogger(SortCommandParser.class.getName());
+
+    /**
+     * Parses the given prefix string and returns a SortCommand.
+     *
+     * @param args The arguments string provided by the user.
+     * @return SortCommand object based on the specified sorting attribute.
+     * @throws ParseException Prefix is invalid or the arguments are not recognized.
+     */
     public SortCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         switch (trimmedArgs) {

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -10,22 +10,35 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-public class SortCommandParser implements Parser<SortCommand> {
+import java.util.logging.Logger;
 
+public class SortCommandParser implements Parser<SortCommand> {
+    private static final Logger logger = Logger.getLogger(SortCommandParser.class.getName());
     public SortCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
-
-        if (trimmedArgs.equals(PREFIX_NAME.getPrefix())) {
+        switch (trimmedArgs) {
+        case "n/":
+            logger.info("Sorting by name.");
             return new SortCommand(PREFIX_NAME.getPrefix());
-        } else if (trimmedArgs.equals(PREFIX_PHONE.getPrefix())) {
+
+        case "p/":
+            logger.info("Sorting by phone.");
             return new SortCommand(PREFIX_PHONE.getPrefix());
-        } else if (trimmedArgs.equals(PREFIX_EMAIL.getPrefix())) {
+
+        case "e/":
+            logger.info("Sorting by email.");
             return new SortCommand(PREFIX_EMAIL.getPrefix());
-        } else if (trimmedArgs.equals(PREFIX_ADDRESS.getPrefix())) {
+
+        case "a/":
+            logger.info("Sorting by address.");
             return new SortCommand(PREFIX_ADDRESS.getPrefix());
-        } else if (trimmedArgs.equals(PREFIX_TAG.getPrefix())) {
+
+        case "t/":
+            logger.info("Sorting by tag.");
             return new SortCommand(PREFIX_TAG.getPrefix());
-        } else {
+
+        default:
+            logger.warning("Invalid sorting prefix provided: " + trimmedArgs);
             throw new ParseException(String.format(MESSAGE_SORT_UNSUCCESSFUL, SortCommand.MESSAGE_USAGE));
         }
     }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -4,7 +4,11 @@ import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 import static seedu.address.logic.Messages.MESSAGE_SORT_UNSUCCESSFUL;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 public class SortCommandParser implements Parser<SortCommand> {
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -98,6 +98,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.pinPerson(person);
     }
 
+    /**
+     * Updates the list of persons in the address book by sorting them based on the given prefix.
+     *
+     * @param prefix The prefix used for sorting of the person list.
+     */
+    public void updateSortedList(String prefix) {
+        persons.sortBy(prefix);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,12 +1,10 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,10 +1,12 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -98,5 +100,17 @@ public interface Model {
      */
     ObservableList<String> getCommandInputHistoryList();
 
+    /**
+     * Pins a person in the address book to the top of the list.
+     *
+     * @param personToPin The person to be pinned in the address book.
+     */
     void pinPerson(Person personToPin);
+
+    /**
+     * Updates the filtered and sorted list of persons based on the specified prefix attribute
+     *
+     * @param prefix The prefix indicating the attribute to sort by.
+     */
+    void updateSortedFilteredPersonList(String prefix);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -23,6 +24,8 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final InputHistory pastCommands;
+    private final ObservableList<Person> personList;
+    private final SortedList<Person> sortedFilteredPersons;
 
 
     /**
@@ -37,6 +40,8 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         pastCommands = new InputHistory();
+        this.personList = addressBook.getPersonList();
+        sortedFilteredPersons = new SortedList<>(filteredPersons);
     }
 
     public ModelManager() {
@@ -127,7 +132,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Person> getFilteredPersonList() {
-        return filteredPersons;
+        return sortedFilteredPersons;
     }
 
     @Override
@@ -146,6 +151,21 @@ public class ModelManager implements Model {
         return pastCommands.getPastCommands();
     }
 
+    //=========== Sorted Person List Accessors =============================================================
+
+    /**
+     * Updates the sorted and filtered person list based on the given prefix.The prefix is used to
+     * filter the list of persons in the address book and sort the resulting filtered list.
+     *
+     * @param prefix The string prefix used to filter and sort the person list.
+     * @throws NullPointerException if prefix is null.
+     */
+    @Override
+    public void updateSortedFilteredPersonList(String prefix) {
+        requireNonNull(prefix);
+        addressBook.updateSortedList(prefix);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -160,7 +180,7 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+                //&& filteredPersons.equals(otherModelManager.filteredPersons);
+                && sortedFilteredPersons.equals(otherModelManager.sortedFilteredPersons);
     }
-
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -167,21 +167,55 @@ public class UniquePersonList implements Iterable<Person> {
         return true;
     }
 
+    /**
+     * Sorts the list of persons based on the specified prefix such as name, phone number, email address, address.
+     *
+     * @param prefix The prefix indicates the sorting criteria.
+     */
     public void sortBy(String prefix) {
         switch (prefix) {
-            case "n/":
-                sortByName();
-                break;
-            default:
-                break;
-        }
+        case "n/":
+            sortByName();
+            break;
+        case "p/":
+            sortByPhoneNumber();
+            break;
+        case "e/":
+            sortByEmailAddress();
+            break;
+        case "a/":
+            sortByAddress();
+            break;
+        default:
+            break;
+       }
     }
 
     /**
-     * Sorts the list by name.
+     * Sort the list by name.
      */
     private void sortByName() {
         internalList.sort(Comparator.comparing(p -> p.getName().toString()));
     }
 
+    /**
+     * Sort the list by phone number.
+     */
+    private void sortByPhoneNumber() {
+        internalList.sort(Comparator.comparing(p -> Integer.parseInt(p.getPhone().toString())));
+    }
+
+    /**
+     * Sort the list by email address.
+     */
+    private void sortByEmailAddress() {
+        internalList.sort(Comparator.comparing(p -> p.getEmail().toString()));
+    }
+
+    /**
+     * Sort the list by address.
+     */
+    private void sortByAddress() {
+        internalList.sort(Comparator.comparing(p -> p.getAddress().toString()));
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -165,4 +166,22 @@ public class UniquePersonList implements Iterable<Person> {
         }
         return true;
     }
+
+    public void sortBy(String prefix) {
+        switch (prefix) {
+            case "n/":
+                sortByName();
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Sorts the list by name.
+     */
+    private void sortByName() {
+        internalList.sort(Comparator.comparing(p -> p.getName().toString()));
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -191,7 +191,7 @@ public class UniquePersonList implements Iterable<Person> {
             break;
         default:
             break;
-       }
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -168,7 +168,7 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Sorts the list of persons based on the specified prefix such as name, phone number, email address, address.
+     * Sorts the list of persons based on the specified prefix such as name, phone number, email address, address, tags.
      *
      * @param prefix The prefix indicates the sorting criteria.
      */
@@ -185,6 +185,9 @@ public class UniquePersonList implements Iterable<Person> {
             break;
         case "a/":
             sortByAddress();
+            break;
+        case "t/":
+            sortByTags();
             break;
         default:
             break;
@@ -217,5 +220,12 @@ public class UniquePersonList implements Iterable<Person> {
      */
     private void sortByAddress() {
         internalList.sort(Comparator.comparing(p -> p.getAddress().toString()));
+    }
+
+    /**
+     * Sort the list by tags.
+     */
+    private void sortByTags() {
+        internalList.sort(Comparator.comparing(p -> p.getTags().toString()));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -172,6 +172,11 @@ public class AddCommandTest {
         public ObservableList<String> getCommandInputHistoryList() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void updateSortedFilteredPersonList(String prefix) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,130 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code SortCommand}.
+ */
+public class SortCommandTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        // Create a new AddressBook and ModelManager instance for each test
+        AddressBook addressBook = new AddressBook();
+        UserPrefs userPrefs = new UserPrefs();
+        model = new ModelManager(addressBook, userPrefs);
+    }
+
+    @Test
+    public void execute_sortByName_success() throws DuplicatePersonException {
+        model.addPerson(BENSON);
+        model.addPerson(ALICE);
+        model.addPerson(ELLE);
+        model.addPerson(DANIEL);
+        model.addPerson(CARL);
+        SortCommand sortCommand = new SortCommand("n/");
+        sortCommand.execute(model);
+
+        // Check if the persons in AddressBook are sorted correctly by name
+        assertEquals("Alice Pauline", model.getFilteredPersonList().get(0).getName().toString());
+        assertEquals("Benson Meier", model.getFilteredPersonList().get(1).getName().toString());
+        assertEquals("Carl Kurz", model.getFilteredPersonList().get(2).getName().toString());
+        assertEquals("Daniel Meier", model.getFilteredPersonList().get(3).getName().toString());
+        assertEquals("Elle Meyer", model.getFilteredPersonList().get(4).getName().toString());
+    }
+
+    @Test
+    public void execute_sortByPhone_success() throws DuplicatePersonException {
+        model.addPerson(BENSON);
+        model.addPerson(ALICE);
+        model.addPerson(ELLE);
+        model.addPerson(DANIEL);
+        model.addPerson(CARL);
+
+        SortCommand sortCommand = new SortCommand("p/");
+        sortCommand.execute(model);
+
+        // Check if the persons in AddressBook are sorted correctly by phone
+        assertEquals("9482224", model.getFilteredPersonList().get(0).getPhone().toString());
+        assertEquals("87652533", model.getFilteredPersonList().get(1).getPhone().toString());
+        assertEquals("94351253", model.getFilteredPersonList().get(2).getPhone().toString());
+        assertEquals("95352563", model.getFilteredPersonList().get(3).getPhone().toString());
+        assertEquals("98765432", model.getFilteredPersonList().get(4).getPhone().toString());
+    }
+
+    @Test
+    public void execute_sortByEmail_success() throws DuplicatePersonException {
+        model.addPerson(BENSON);
+        model.addPerson(ALICE);
+        model.addPerson(ELLE);
+        model.addPerson(DANIEL);
+        model.addPerson(CARL);
+
+        SortCommand sortCommand = new SortCommand("e/");
+        sortCommand.execute(model);
+
+        // Check if the persons in AddressBook are sorted correctly by email
+        assertEquals("alice@example.com", model.getFilteredPersonList().get(0).getEmail().toString());
+        assertEquals("cornelia@example.com", model.getFilteredPersonList().get(1).getEmail().toString());
+        assertEquals("heinz@example.com", model.getFilteredPersonList().get(2).getEmail().toString());
+        assertEquals("johnd@example.com", model.getFilteredPersonList().get(3).getEmail().toString());
+        assertEquals("werner@example.com", model.getFilteredPersonList().get(4).getEmail().toString());
+    }
+
+    @Test
+    public void execute_sortByAddress_success() throws DuplicatePersonException {
+        model.addPerson(BENSON);
+        model.addPerson(ALICE);
+        model.addPerson(ELLE);
+        model.addPerson(DANIEL);
+        model.addPerson(CARL);
+
+        SortCommand sortCommand = new SortCommand("a/");
+        sortCommand.execute(model);
+
+        // Check if the persons in AddressBook are sorted correctly by address
+        assertEquals("10th street", model.getFilteredPersonList().get(0).getAddress().toString());
+        assertEquals("123, Jurong West Ave 6, #08-111", model.getFilteredPersonList().get(1).getAddress().toString());
+        assertEquals("311, Clementi Ave 2, #02-25", model.getFilteredPersonList().get(2).getAddress().toString());
+        assertEquals("michegan ave", model.getFilteredPersonList().get(3).getAddress().toString());
+        assertEquals("wall street", model.getFilteredPersonList().get(4).getAddress().toString());
+    }
+
+    @Test
+    public void execute_sortByTags_success() throws DuplicatePersonException {
+        model.addPerson(BENSON);
+        model.addPerson(ALICE);
+        model.addPerson(ELLE);
+        model.addPerson(DANIEL);
+        model.addPerson(CARL);
+
+        // Sort the persons by tags
+        SortCommand sortCommand = new SortCommand("t/");
+        sortCommand.execute(model);
+
+        // Check if the persons are sorted correctly by tags (alphabetical order of tags)
+        assertTrue(model.getFilteredPersonList().get(0).getTags().toString().contains("friends"));
+        assertTrue(model.getFilteredPersonList().get(1).getTags().toString().contains("friends"));
+        assertTrue(model.getFilteredPersonList().get(2).getTags().toString().contains("friends"));
+        assertTrue(model.getFilteredPersonList().get(2).getTags().toString().contains("owesMoney"));
+        assertTrue(model.getFilteredPersonList().get(3).getTags().isEmpty());
+        assertTrue(model.getFilteredPersonList().get(4).getTags().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -15,7 +15,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 /**

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -16,31 +18,31 @@ public class SortCommandParserTest {
     }
 
     @Test
-    public void parse_validPrefix_name_success() throws ParseException {
+    public void parse_validNamePrefix_success() throws ParseException {
         SortCommand command = parser.parse("n/");
         assertEquals(CliSyntax.PREFIX_NAME.getPrefix(), command.getSortPrefix());
     }
 
     @Test
-    public void parse_validPrefix_phone_success() throws ParseException {
+    public void parse_validPhonePrefix_success() throws ParseException {
         SortCommand command = parser.parse("p/");
         assertEquals(CliSyntax.PREFIX_PHONE.getPrefix(), command.getSortPrefix());
     }
 
     @Test
-    public void parse_validPrefix_email_success() throws ParseException {
+    public void parse_validEmailPrefix_success() throws ParseException {
         SortCommand command = parser.parse("e/");
         assertEquals(CliSyntax.PREFIX_EMAIL.getPrefix(), command.getSortPrefix());
     }
 
     @Test
-    public void parse_validPrefix_address_success() throws ParseException {
+    public void parse_validAddressPrefix_success() throws ParseException {
         SortCommand command = parser.parse("a/");
         assertEquals(CliSyntax.PREFIX_ADDRESS.getPrefix(), command.getSortPrefix());
     }
 
     @Test
-    public void parse_validPrefix_tag_success() throws ParseException {
+    public void parse_validTagPrefix_success() throws ParseException {
         SortCommand command = parser.parse("t/");
         assertEquals(CliSyntax.PREFIX_TAG.getPrefix(), command.getSortPrefix());
     }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class SortCommandParserTest {
+    private SortCommandParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = new SortCommandParser();
+    }
+
+    @Test
+    public void parse_validPrefix_name_success() throws ParseException {
+        SortCommand command = parser.parse("n/");
+        assertEquals(CliSyntax.PREFIX_NAME.getPrefix(), command.getSortPrefix());
+    }
+
+    @Test
+    public void parse_validPrefix_phone_success() throws ParseException {
+        SortCommand command = parser.parse("p/");
+        assertEquals(CliSyntax.PREFIX_PHONE.getPrefix(), command.getSortPrefix());
+    }
+
+    @Test
+    public void parse_validPrefix_email_success() throws ParseException {
+        SortCommand command = parser.parse("e/");
+        assertEquals(CliSyntax.PREFIX_EMAIL.getPrefix(), command.getSortPrefix());
+    }
+
+    @Test
+    public void parse_validPrefix_address_success() throws ParseException {
+        SortCommand command = parser.parse("a/");
+        assertEquals(CliSyntax.PREFIX_ADDRESS.getPrefix(), command.getSortPrefix());
+    }
+
+    @Test
+    public void parse_validPrefix_tag_success() throws ParseException {
+        SortCommand command = parser.parse("t/");
+        assertEquals(CliSyntax.PREFIX_TAG.getPrefix(), command.getSortPrefix());
+    }
+
+    @Test
+    public void parse_invalidPrefix_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> {
+            parser.parse("abc/");
+        });
+        assertEquals("Invalid prefix used.", exception.getMessage());
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> {
+            parser.parse("");
+        });
+        assertEquals("Invalid prefix used.", exception.getMessage());
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -6,8 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.*;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -103,6 +102,21 @@ public class AddressBookTest {
         public ObservableList<Person> getPersonList() {
             return persons;
         }
+    }
+
+    @Test
+    public void updateSortedList_sortByPrefix_updatesCorrectly() {
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(BENSON);
+        addressBook.addPerson(ALICE);
+        addressBook.addPerson(CARL);
+
+        addressBook.updateSortedList("n/");
+
+        ObservableList<Person> personList = addressBook.getPersonList();
+        assertEquals("Alice Pauline", personList.get(0).getName().toString());
+        assertEquals("Benson Meier", personList.get(1).getName().toString());
+        assertEquals("Carl Kurz", personList.get(2).getName().toString());
     }
 
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.*;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -20,6 +22,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
 
 public class AddressBookTest {
 
@@ -41,6 +44,15 @@ public class AddressBookTest {
         addressBook.resetData(newData);
         assertEquals(newData, addressBook);
     }
+
+    private AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Person p : TypicalPersons.getTypicalPersons()) {
+            ab.addPerson(p);
+        }
+        return ab;
+    }
+
 
     @Test
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -12,10 +12,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import javafx.collections.ObservableList;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -91,6 +93,17 @@ public class ModelManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void updateSortedFilteredPersonList_validPrefix_updatesListCorrectly() {
+        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
+        modelManager = new ModelManager(addressBook, new UserPrefs());
+        modelManager.updateSortedFilteredPersonList("n/");
+        ObservableList<Person> filteredList = modelManager.getFilteredPersonList();
+        assertEquals(2, filteredList.size());
+        assertTrue(filteredList.contains(ALICE));
+        assertTrue(filteredList.contains(BENSON));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -12,9 +12,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import javafx.collections.ObservableList;
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -185,4 +185,52 @@ public class UniquePersonListTest {
     public void toStringMethod() {
         assertEquals(uniquePersonList.asUnmodifiableObservableList().toString(), uniquePersonList.toString());
     }
+
+    @Test
+    public void sortBy_namePrefix_sortsByName() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        uniquePersonList.sortBy("n/");
+        assertEquals(ALICE, uniquePersonList.asUnmodifiableObservableList().get(0));
+    }
+
+    @Test
+    public void sortBy_phonePrefix_sortsByPhone() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        uniquePersonList.sortBy("p/");
+        assertEquals(BOB, uniquePersonList.asUnmodifiableObservableList().get(0));
+    }
+
+    @Test
+    public void sortBy_emailPrefix_sortsByEmail() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        uniquePersonList.sortBy("e/");
+        assertEquals(ALICE, uniquePersonList.asUnmodifiableObservableList().get(0));
+    }
+
+    @Test
+    public void sortBy_addressPrefix_sortsByAddress() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        uniquePersonList.sortBy("a/");
+        assertEquals(ALICE, uniquePersonList.asUnmodifiableObservableList().get(0));
+    }
+
+    @Test
+    public void sortBy_tagsPrefix_sortsByTags() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        uniquePersonList.sortBy("t/");
+        assertEquals(BOB, uniquePersonList.asUnmodifiableObservableList().get(0));
+    }
+
+    @Test
+    public void sortBy_invalidPrefix_doesNothing() {
+        uniquePersonList.add(BOB);
+        uniquePersonList.add(ALICE);
+        uniquePersonList.sortBy("invalidPrefix");
+        assertEquals(BOB, uniquePersonList.asUnmodifiableObservableList().get(0));
+    }
 }


### PR DESCRIPTION
Fixes #48 
Sort using single prefix without pinned list. For example: `sort n/` to sort names, `sort p/` to sort phone number, `sort e/` to sort email, `sort a/` to sort address, `sort t/` to sort tags.