### PR TITLE
Feat - Command History GUI

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -34,7 +34,7 @@ public interface Logic {
     ObservableList<Person> getFilteredPersonList();
 
     /**
-     * Returns an unmodifiable view of an ordered (tail element being the latest),
+     * Returns an unmodifiable view of an ordered (head element being the latest),
      * observable list of past commands.
      */
     ObservableList<String> getCommandHistoryList();

--- a/src/main/java/seedu/address/model/InputHistory.java
+++ b/src/main/java/seedu/address/model/InputHistory.java
@@ -29,9 +29,9 @@ public class InputHistory {
      */
     public void addInput(String commandInput) {
         if (pastCommands.size() == MAX_HISTORY_SIZE) {
-            pastCommands.remove(0);
+            pastCommands.remove(MAX_HISTORY_SIZE - 1);
         }
-        pastCommands.add(commandInput);
+        pastCommands.add(0, commandInput);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -94,7 +94,7 @@ public interface Model {
 
     /**
      * Returns an unmodifiable ordered view of the list of past command inputs.
-     * The most recent input is at the tail.
+     * The most recently added input is at the front of the list.
      */
     ObservableList<String> getCommandInputHistoryList();
 

--- a/src/main/java/seedu/address/ui/CommandHistoryMenu.java
+++ b/src/main/java/seedu/address/ui/CommandHistoryMenu.java
@@ -33,22 +33,41 @@ public class CommandHistoryMenu extends UiPart<Region> implements CommandHistory
         super(FXML);
         commandHistoryList.setItems(commandHistory);
         controller = new CommandHistoryMenuController(commandHistory, commandSetter);
+
+        commandHistoryList.getSelectionModel().selectedIndexProperty()
+                .addListener((observable, oldValue, newValue) -> {
+                    if (newValue.intValue() >= 0) {
+                        commandHistoryList.scrollTo(newValue.intValue());
+                    }
+                    controller.setSelection(newValue.intValue());
+                });
+
+        // set default visibility to hidden
+        this.getRoot().setVisible(false);
     }
 
 
     @Override
     public void handleMovementUp() {
+        this.getRoot().setVisible(true);
         controller.moveUp();
+        controller.getCommandSelectionIndex()
+                .ifPresent(index -> commandHistoryList.getSelectionModel().select(index));
     }
 
     @Override
     public void handleMovementDown() {
+        this.getRoot().setVisible(true);
         controller.moveDown();
+        controller.getCommandSelectionIndex()
+                .ifPresent(index -> commandHistoryList.getSelectionModel().select(index));
     }
 
     @Override
-    public void handleEnterPressed() {
-        controller.resetSelection();
+    public void handleCloseAction() {
+        controller.clearSelection();
+        commandHistoryList.getSelectionModel().clearSelection();
+        this.getRoot().setVisible(false);
     }
 
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -138,6 +138,7 @@ public class MainWindow extends UiPart<Stage> {
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
         commandHistoryMenu = new CommandHistoryMenu(logic.getCommandHistoryList(), commandBox::setCommandTextField);
+        resultDisplayPlaceholder.getChildren().add(commandHistoryMenu.getRoot());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/controller/CommandHistoryActionHandler.java
+++ b/src/main/java/seedu/address/ui/controller/CommandHistoryActionHandler.java
@@ -17,7 +17,8 @@ public interface CommandHistoryActionHandler {
     void handleMovementDown();
 
     /**
+     * Handles the Escape or Enter key pressed events.
      * Resets the selected input to the default index value.
      */
-    void handleEnterPressed();
+    void handleCloseAction();
 }

--- a/src/main/java/seedu/address/ui/controller/CommandHistoryMenuController.java
+++ b/src/main/java/seedu/address/ui/controller/CommandHistoryMenuController.java
@@ -1,22 +1,28 @@
 package seedu.address.ui.controller;
 
+import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import seedu.address.commons.core.LogsCenter;
 
 /**
  * Represents the controller for the command history menu ui component.
  */
 public final class CommandHistoryMenuController {
     static final int DEFAULT_SELECTION_INDEX = 0;
+    private static final Logger logger = LogsCenter.getLogger(CommandHistoryMenuController.class);
 
     final ObservableList<String> pastCommands;
     final CommandBoxInputSetter commandSetter;
 
-    private int commandSelectionIndex = DEFAULT_SELECTION_INDEX;
+
+    private Optional<Integer> commandSelectionIndex;
 
     /**
      * Creates a {@code CommandHistoryMenuController}
@@ -29,17 +35,8 @@ public final class CommandHistoryMenuController {
             ObservableList<String> commandHistory, CommandBoxInputSetter commandSetter) {
         this.commandSetter = commandSetter;
         pastCommands = commandHistory;
-    }
-
-    /**
-     * Moves the command history selection up.
-     */
-    public void moveUp() {
-        if (pastCommands.isEmpty()) {
-            return;
-        }
-        commandSelectionIndex = (commandSelectionIndex + 1) % pastCommands.size();
-        setInputToSelection();
+        // initially, none are selected
+        commandSelectionIndex = Optional.empty();
     }
 
     /**
@@ -49,22 +46,46 @@ public final class CommandHistoryMenuController {
         if (pastCommands.isEmpty()) {
             return;
         }
-        commandSelectionIndex = (pastCommands.size() + commandSelectionIndex - 1) % pastCommands.size();
-        assert commandSelectionIndex >= 0 && commandSelectionIndex < pastCommands.size();
+        commandSelectionIndex = commandSelectionIndex
+                .map(previousSelectionIndex -> (previousSelectionIndex + 1) % pastCommands.size())
+                .or(() -> Optional.of(DEFAULT_SELECTION_INDEX));
         setInputToSelection();
     }
+
     /**
-     * Resets the selected input to the default index value.
+     * Moves the command history selection up.
      */
-    public void resetSelection() {
-        commandSelectionIndex = DEFAULT_SELECTION_INDEX;
+    public void moveUp() {
+        if (pastCommands.isEmpty()) {
+            return;
+        }
+        commandSelectionIndex = commandSelectionIndex
+                .map(previousSelectionIndex
+                        -> (pastCommands.size() + previousSelectionIndex - 1) % pastCommands.size())
+                .or(() -> Optional.of(DEFAULT_SELECTION_INDEX));
+        setInputToSelection();
+    }
+
+    public void setSelection(int commandSelectionIndex) {
+        logger.log(Level.INFO, "Got selection index: " + commandSelectionIndex);
+        if (commandSelectionIndex < 0 || commandSelectionIndex >= pastCommands.size()) {
+            return;
+        }
+        this.commandSelectionIndex = Optional.of(commandSelectionIndex);
+        setInputToSelection();
+    }
+
+    public void clearSelection() {
+        commandSelectionIndex = Optional.empty();
     }
 
     private void setInputToSelection() {
-        commandSetter.setCommandInput(pastCommands.get(commandSelectionIndex));
+        commandSelectionIndex.ifPresent(index -> {
+            commandSetter.setCommandInput(pastCommands.get(index));
+        });
     }
 
-    int getCommandSelectionIndex() {
+    public Optional<Integer> getCommandSelectionIndex() {
         return commandSelectionIndex;
     }
 
@@ -80,6 +101,7 @@ public final class CommandHistoryMenuController {
             boolean isPageUpAndCtrlDown = event.getCode() == KeyCode.UP && event.isControlDown();
             boolean isPageDownAndCtrlDown = event.getCode() == KeyCode.DOWN && event.isControlDown();
             boolean isEnterPressed = event.getCode() == KeyCode.ENTER;
+            boolean isEscPressed = event.getCode() == KeyCode.ESCAPE;
 
             if (isPageUpAndCtrlDown) {
                 handlerSupplier.get().handleMovementUp();
@@ -91,8 +113,8 @@ public final class CommandHistoryMenuController {
                 event.consume();
                 return;
             }
-            if (isEnterPressed) {
-                handlerSupplier.get().handleEnterPressed();
+            if (isEnterPressed || isEscPressed) {
+                handlerSupplier.get().handleCloseAction();
             }
         };
     }

--- a/src/main/resources/view/CommandHistoryMenu.css
+++ b/src/main/resources/view/CommandHistoryMenu.css
@@ -1,0 +1,26 @@
+.list-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+    -fx-background-color: derive(#1d1d1d, 20%);
+}
+
+.list-cell {
+    -fx-label-padding: 0 0 0 0;
+    -fx-graphic-text-gap : 0;
+    -fx-padding: 1 1 1 1;
+    -fx-text-fill: white;
+    -fx-font-size: 16px;
+}
+
+.list-cell:filled:even {
+    -fx-background-color: #515658;
+}
+
+.list-cell:filled:odd {
+    -fx-background-color: #515658;
+}
+
+.list-cell:filled:selected {
+    -fx-background-color: #424d5f;
+}
+

--- a/src/main/resources/view/CommandHistoryMenu.css
+++ b/src/main/resources/view/CommandHistoryMenu.css
@@ -1,15 +1,23 @@
 .list-view {
     -fx-background-insets: 0;
-    -fx-padding: 0;
+    -fx-padding: 1;
     -fx-background-color: derive(#1d1d1d, 20%);
 }
 
 .list-cell {
-    -fx-label-padding: 0 0 0 0;
+    -fx-label-padding: 1 1 1 1;
     -fx-graphic-text-gap : 0;
     -fx-padding: 1 1 1 1;
     -fx-text-fill: white;
     -fx-font-size: 16px;
+}
+
+.list-cell:even {
+    -fx-background-color: #515658;
+}
+
+.list-cell:odd {
+    -fx-background-color: #515658;
 }
 
 .list-cell:filled:even {

--- a/src/main/resources/view/CommandHistoryMenu.fxml
+++ b/src/main/resources/view/CommandHistoryMenu.fxml
@@ -3,8 +3,8 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane xmlns="http://javafx.com/javafx"
+<StackPane xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             prefHeight="400.0" prefWidth="600.0">
-    <ListView fx:id="commandHistoryList" VBox.vgrow="ALWAYS" />
-</AnchorPane>
+    <ListView fx:id="commandHistoryList" VBox.vgrow="ALWAYS" styleClass="history-menu"/>
+</StackPane>

--- a/src/main/resources/view/CommandHistoryMenu.fxml
+++ b/src/main/resources/view/CommandHistoryMenu.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="600.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <ListView fx:id="commandHistoryList" stylesheets="@CommandHistoryMenu.css" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/CommandHistoryMenu.fxml
+++ b/src/main/resources/view/CommandHistoryMenu.fxml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
 
-<StackPane xmlns="http://javafx.com/javafx"
-            xmlns:fx="http://javafx.com/fxml"
-            prefHeight="400.0" prefWidth="600.0">
-    <ListView fx:id="commandHistoryList" VBox.vgrow="ALWAYS" styleClass="history-menu"/>
-</StackPane>
+<VBox prefHeight="600.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="commandHistoryList" stylesheets="@CommandHistoryMenu.css" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -14,6 +14,8 @@ import static seedu.address.testutil.TypicalPersons.AMY;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +97,9 @@ public class LogicManagerTest {
                 // Ignored as invalid inputs should also be saved to history.
             }
         }
-        assertEquals(List.of(dummyCommands), logic.getCommandHistoryList());
+        List<String> expectedList = Arrays.asList(dummyCommands);
+        Collections.reverse(expectedList);
+        assertEquals(expectedList, logic.getCommandHistoryList());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/InputHistoryTest.java
+++ b/src/test/java/seedu/address/model/InputHistoryTest.java
@@ -22,10 +22,10 @@ public class InputHistoryTest {
         }
         ObservableList<String> previousCommands = emptyInputHistory.getPastCommands();
         assertEquals(20, previousCommands.size());
-        assertEquals("input 0", previousCommands.get(0));
+        assertEquals("input 19", previousCommands.get(0));
 
-        emptyInputHistory.addInput("input 21");
-        assertEquals("input 1", previousCommands.get(0));
-        assertEquals("input 21", previousCommands.get(19));
+        emptyInputHistory.addInput("input 20");
+        assertEquals("input 20", previousCommands.get(0));
+        assertEquals("input 1", previousCommands.get(19));
     }
 }

--- a/src/test/java/seedu/address/ui/controller/CommandHistoryMenuControllerTest.java
+++ b/src/test/java/seedu/address/ui/controller/CommandHistoryMenuControllerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,63 +28,73 @@ public class CommandHistoryMenuControllerTest {
     }
 
     @Test
-    public void moveUp_emptyList_noChange() {
+    public void moveUp_emptyList_noSelection() {
         controller.moveUp();
-        assertEquals(
-                CommandHistoryMenuController.DEFAULT_SELECTION_INDEX,
-                controller.getCommandSelectionIndex());
+        assertEquals(Optional.empty(), controller.getCommandSelectionIndex());
     }
 
     @Test
-    public void moveUp_multipleElementsMoveUp_incrementsOnce() {
+    public void moveUp_multipleElementsMoveUp_selectsDefaultIndex() {
         controller = new CommandHistoryMenuController(
-                nonEmptyCommandHistory, text -> assertEquals(nonEmptyCommandHistory.get(1), text));
+                nonEmptyCommandHistory, text -> assertEquals(nonEmptyCommandHistory.get(0), text));
         controller.moveUp();
-        assertEquals(1, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(0, controller.getCommandSelectionIndex().get());
     }
 
     @Test
     public void moveUp_multipleElementsLastSelected_wrapsAround() {
         controller = new CommandHistoryMenuController(
                 nonEmptyCommandHistory, text -> {});
-        assertEquals(0, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isEmpty());
+
         controller.moveUp();
-        assertEquals(1, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(0, controller.getCommandSelectionIndex().get());
+
         controller.moveUp();
-        assertEquals(2, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(2, controller.getCommandSelectionIndex().get());
+
         controller.moveUp();
-        assertEquals(0, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(1, controller.getCommandSelectionIndex().get());
     }
 
     @Test
-    public void moveDown_emptyList_noChange() {
+    public void moveDown_emptyList_noSelection() {
         controller.moveDown();
-        assertEquals(
-                CommandHistoryMenuController.DEFAULT_SELECTION_INDEX,
-                controller.getCommandSelectionIndex());
+        assertEquals(Optional.empty(), controller.getCommandSelectionIndex());
     }
 
     @Test
     public void moveDown_multipleElements_decrementsCorrectly() {
         controller = new CommandHistoryMenuController(nonEmptyCommandHistory, text -> {});
-        assertEquals(0, controller.getCommandSelectionIndex());
+        assertEquals(Optional.empty(), controller.getCommandSelectionIndex());
+
         controller.moveDown();
-        assertEquals(2, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(0, controller.getCommandSelectionIndex().get());
+
         controller.moveDown();
-        assertEquals(1, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(1, controller.getCommandSelectionIndex().get());
+
         controller.moveDown();
-        assertEquals(0, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(2, controller.getCommandSelectionIndex().get());
     }
 
     @Test
     public void resetSelection_multipleElements_resetsToZero() {
         controller = new CommandHistoryMenuController(FXCollections.observableArrayList("test1", "test2", "test3"),
                 text -> {});
-        assertEquals(0, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isEmpty());
         controller.moveUp();
-        assertEquals(1, controller.getCommandSelectionIndex());
-        controller.resetSelection();
-        assertEquals(0, controller.getCommandSelectionIndex());
+        assertTrue(controller.getCommandSelectionIndex().isPresent());
+        assertEquals(0, controller.getCommandSelectionIndex().get());
+        controller.clearSelection();
+        assertTrue(controller.getCommandSelectionIndex().isEmpty());
     }
 
     private KeyEvent getMovementDownKeyEvent() {
@@ -160,7 +172,7 @@ public class CommandHistoryMenuControllerTest {
         }
 
         @Override
-        public void handleEnterPressed() {
+        public void handleCloseAction() {
             isEnterPressedCalled = true;
         }
     }


### PR DESCRIPTION
Closes #47

Implements a simple GUI over result display when history is activated (via `Ctrl + Down` or `Ctrl + Up` key combinations)
Pressing `Escape` or `Enter` should close the history region.