### PR TITLE
Enhancement: Mass ops delete

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,5 +1,8 @@
 package seedu.address.logic;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,6 +53,19 @@ public class Messages {
         builder.append("; Note: ")
                 .append(person.getNote());
         return builder.toString();
+    }
+
+    /**
+     * Formats a group of persons for display to the user.
+     *
+     * @param persons The group of persons to be formatted.
+     * @return The formatted string to be displayed.
+     */
+    public static String format(Collection<? extends Person> persons) {
+        requireAllNonNull(persons);
+        return persons.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining(System.lineSeparator()));
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,7 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -19,30 +22,74 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the person(s) identified by the index number(s) used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)"
+            + System.lineSeparator()
+            + "Example: " + COMMAND_WORD + " 1"
+            + System.lineSeparator()
+            + "For deleting multiple persons at once:"
+            + System.lineSeparator()
+            + "1. (Spaced format) Parameters: m/INDEX1 INDEX2 INDEX3 ... INDEXN (Each INDEX must be a positive "
+            + "integer.)"
+            + System.lineSeparator()
+            + " Example: " + COMMAND_WORD + " m/1 2 3 4 5"
+            + System.lineSeparator()
+            + "2. (Ranged format) Parameters: m/START_INDEX-END_INDEX (START_INDEX and END_INDEX "
+            + "must be a positive integer.)"
+            + System.lineSeparator()
+            + " Example: " + COMMAND_WORD + " m/9-99";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s): "
+            + System.lineSeparator()
+            + "%1$s";
 
-    private final Index targetIndex;
+    /** Specifies the highest index to be the element at the start of {@code targetIndexes}. */
+    private static final Integer HIGHEST_TARGET_INDEX_POSITION = 0;
+    /**
+     * This instance variable must obey the following constraints:
+     * 1. Unique
+     * 2. decreasing order (by 0-based index)
+     * 3. Immutable
+     * 4. Non-empty
+     */
+    private final List<Index> targetIndexes;
 
     public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+        this.targetIndexes = Collections.singletonList(targetIndex);
+    }
+
+    /**
+     * Creates a delete command specifying multiple unique indexes to delete.
+     *
+     * @param targetIndexes The indexes of persons to be deleted.
+     */
+    public DeleteCommand(Set<Index> targetIndexes) {
+        this.targetIndexes = List.copyOf(targetIndexes
+                .stream()
+                .sorted((index1, index2) -> index2.getZeroBased() - index1.getZeroBased())
+                .toList());
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        assert !targetIndexes.isEmpty();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+        List<Person> lastShownList = model.getFilteredPersonList();
+        // Delete operation fails (uncommited) if at least 1 index is out of range
+        if (targetIndexes.get(HIGHEST_TARGET_INDEX_POSITION).getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+        List<Person> deletedPersons = new ArrayList<>();
+        for (Index targetIndex : targetIndexes) {
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            model.deletePerson(personToDelete);
 
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+            deletedPersons.add(personToDelete);
+        }
+
+        Collections.reverse(deletedPersons);
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(deletedPersons)));
     }
 
     @Override
@@ -57,13 +104,15 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        return targetIndexes.equals(otherDeleteCommand.targetIndexes);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .add("targetIndex", targetIndex)
-                .toString();
+        ToStringBuilder builder = new ToStringBuilder(this);
+        for (Index targetIndex : targetIndexes) {
+            builder.add("targetIndex", targetIndex);
+        }
+        return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -29,15 +29,15 @@ public class DeleteCommand extends Command {
             + System.lineSeparator()
             + "For deleting multiple persons at once:"
             + System.lineSeparator()
-            + "1. (Spaced format) Parameters: m/INDEX1 INDEX2 INDEX3 ... INDEXN (Each INDEX must be a positive "
+            + "1. (Spaced format) Parameters: i/INDEX1 INDEX2 INDEX3 ... INDEXN (Each INDEX must be a positive "
             + "integer.)"
             + System.lineSeparator()
-            + " Example: " + COMMAND_WORD + " m/1 2 3 4 5"
+            + " Example: " + COMMAND_WORD + " i/1 2 3 4 5"
             + System.lineSeparator()
-            + "2. (Ranged format) Parameters: m/START_INDEX-END_INDEX (START_INDEX and END_INDEX "
+            + "2. (Ranged format) Parameters: i/START_INDEX-END_INDEX (START_INDEX and END_INDEX "
             + "must be a positive integer.)"
             + System.lineSeparator()
-            + " Example: " + COMMAND_WORD + " m/9-99";
+            + " Example: " + COMMAND_WORD + " i/9-99";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s): "
             + System.lineSeparator()
@@ -45,6 +45,7 @@ public class DeleteCommand extends Command {
 
     /** Specifies the highest index to be the element at the start of {@code targetIndexes}. */
     private static final Integer HIGHEST_TARGET_INDEX_POSITION = 0;
+
     /**
      * This instance variable must obey the following constraints:
      * 1. Unique

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
-    public static final Prefix PREFIX_MASS_OPS = new Prefix("m/");
+    public static final Prefix PREFIX_MASS_OPS = new Prefix("i/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,5 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
+    public static final Prefix PREFIX_MASS_OPS = new Prefix("m/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -36,7 +36,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(massOpsParser.parseIndexes(maybeMassOps.get()));
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MASS_OPS;
+
+import java.util.Optional;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -11,6 +14,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 
+    private final MassOpsIndexParser massOpsParser = new MassOpsIndexParser();
+
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
@@ -18,12 +23,20 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MASS_OPS);
+            // At most one m/ prefix is allowed
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_MASS_OPS);
+
+            Optional<String> maybeMassOps = argMultimap.getValue(PREFIX_MASS_OPS);
+            if (maybeMassOps.isEmpty()) {
+                Index index = ParserUtil.parseIndex(args);
+                return new DeleteCommand(index);
+            }
+
+            return new DeleteCommand(massOpsParser.parseIndexes(maybeMassOps.get()));
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -24,7 +24,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
         try {
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MASS_OPS);
-            // At most one m/ prefix is allowed
+            // At most one such prefix is allowed
             argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_MASS_OPS);
 
             Optional<String> maybeMassOps = argMultimap.getValue(PREFIX_MASS_OPS);

--- a/src/main/java/seedu/address/logic/parser/MassOpsIndexParser.java
+++ b/src/main/java/seedu/address/logic/parser/MassOpsIndexParser.java
@@ -1,0 +1,105 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.StringUtil.isNonZeroUnsignedInteger;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Provides utility methods for parsing multiple 1-based indexes in command arguments.
+ */
+public class MassOpsIndexParser {
+
+    public static final int MAX_OPERATIONS_RANGE = 100;
+    public static final String MESSAGE_OPS_RANGE_TOO_LARGE = "Index range is too large!";
+    public static final String MESSAGE_INVALID_MASS_OPS_FORMAT = "Mass ops index format is invalid.";
+    public static final String MESSAGE_INVALID_INDEX_RANGE = "Invalid index range specified!"
+            + " Start index should be less than or equal to end index.";
+    public static final String MESSAGE_INVALID_INDEX = "Invalid index specified. "
+            + "Index should be a non-zero integer."
+            + System.lineSeparator()
+            + "Valid index formats: 1, 2, 3, ..., " + Integer.MAX_VALUE;
+
+
+    // These two patterns should match mutually exclusively (both cannot be true at the same time).
+    private static final Pattern SPACED_INDEX_PATTERN = Pattern.compile(
+            "(?<indexes>\\d+(?:\\s+\\d+)*)");
+    private static final Pattern RANGE_INDEX_PATTERN = Pattern.compile(
+            "(?<startIndex>\\d+)\\s*-\\s*(?<endIndex>\\d+)"
+    );
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MassOpsIndexParser
+     * and returns a Set of Index objects for execution.
+     * Leading and trailing spaces are ignored in the matching.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Set<Index> parseIndexes(String args) throws ParseException {
+        requireNonNull(args);
+        final Matcher spacedMatcher = SPACED_INDEX_PATTERN.matcher(args.trim());
+        final Matcher rangedMatcher = RANGE_INDEX_PATTERN.matcher(args.trim());
+
+        final boolean isSpacedMatch = spacedMatcher.matches();
+        final boolean isRangedMatch = rangedMatcher.matches();
+        if (!isSpacedMatch && !isRangedMatch) {
+            throw new ParseException(MESSAGE_INVALID_MASS_OPS_FORMAT);
+        }
+        if (isSpacedMatch) {
+            assert !isRangedMatch;
+            return parseSpacedIndexes(spacedMatcher);
+        }
+        return parseRangedIndexes(rangedMatcher);
+
+    }
+
+    private Set<Index> parseRangedIndexes(Matcher rangedMatcher) throws ParseException {
+        requireNonNull(rangedMatcher);
+        assert RANGE_INDEX_PATTERN.equals(rangedMatcher.pattern());
+
+        String startIndexString = rangedMatcher.group("startIndex").trim();
+        String endIndexString = rangedMatcher.group("endIndex").trim();
+
+        final boolean isValidStartIndex = isNonZeroUnsignedInteger(startIndexString);
+        final boolean isValidEndIndex = isNonZeroUnsignedInteger(endIndexString);
+
+        if (!isValidStartIndex || !isValidEndIndex) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
+
+        final int oneBasedStartIndex = Integer.parseInt(startIndexString);
+        final int oneBasedEndIndex = Integer.parseInt(endIndexString);
+
+        if (oneBasedStartIndex > oneBasedEndIndex) {
+            throw new ParseException(MESSAGE_INVALID_INDEX_RANGE);
+        }
+
+        if ((long) oneBasedEndIndex - (long) oneBasedStartIndex + 1 > MAX_OPERATIONS_RANGE) {
+            throw new ParseException(MESSAGE_OPS_RANGE_TOO_LARGE);
+        }
+
+        Set<Index> indexes = new HashSet<>();
+        for (int i = oneBasedStartIndex; i <= oneBasedEndIndex; i++) {
+            indexes.add(Index.fromOneBased(i));
+        }
+
+        return indexes;
+    }
+
+    private Set<Index> parseSpacedIndexes(Matcher spacedMatcher) throws ParseException {
+        requireNonNull(spacedMatcher);
+        assert SPACED_INDEX_PATTERN.equals(spacedMatcher.pattern());
+
+        String rawIndexes = spacedMatcher.group("indexes").trim();
+        Collection<String> oneBasedIndexStrings = Arrays.asList(rawIndexes.split("\\s+"));
+        return ParserUtil.parseIndexes(oneBasedIndexStrings);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/MassOpsIndexParser.java
+++ b/src/main/java/seedu/address/logic/parser/MassOpsIndexParser.java
@@ -15,7 +15,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Provides utility methods for parsing multiple 1-based indexes in command arguments,
- * which are values prefixed with m/ and formatted according to either {@link MassOpsIndexParser#SPACED_INDEX_PATTERN}
+ * which are values prefixed with {@link CliSyntax#PREFIX_MASS_OPS}
+ * and formatted according to either {@link MassOpsIndexParser#SPACED_INDEX_PATTERN}
  * or {@link MassOpsIndexParser#RANGE_INDEX_PATTERN} patterns.
  */
 public class MassOpsIndexParser {
@@ -52,8 +53,8 @@ public class MassOpsIndexParser {
     );
 
     /**
-     * Parses the given string argument according to the spaced and ranged parsing formats.
-     * Space format e.g.: "1 2 3 4 5", Range format: "1-200"
+     * Parses the given string argument according to the spaced and ranged parsing formats. <br/>
+     * Space format e.g.: "1 2 3 4 5", Range format: "1-200". <br/>
      * Returns a Set of Index objects for command execution.
      * Leading and trailing spaces are ignored in the matching.
      *
@@ -61,11 +62,13 @@ public class MassOpsIndexParser {
      */
     public Set<Index> parseIndexes(String args) throws ParseException {
         requireNonNull(args);
+
         final Matcher spacedMatcher = SPACED_INDEX_PATTERN.matcher(args.trim());
         final Matcher rangedMatcher = RANGE_INDEX_PATTERN.matcher(args.trim());
 
         final boolean isSpacedMatch = spacedMatcher.matches();
         final boolean isRangedMatch = rangedMatcher.matches();
+
         if (!isSpacedMatch && !isRangedMatch) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
@@ -73,8 +76,8 @@ public class MassOpsIndexParser {
             assert !isRangedMatch;
             return parseSpacedIndexes(spacedMatcher);
         }
-        return parseRangedIndexes(rangedMatcher);
 
+        return parseRangedIndexes(rangedMatcher);
     }
 
     private Set<Index> parseRangedIndexes(Matcher rangedMatcher) throws ParseException {
@@ -116,6 +119,7 @@ public class MassOpsIndexParser {
 
         String rawIndexes = spacedMatcher.group("indexes").trim();
         Collection<String> oneBasedIndexStrings = Arrays.asList(rawIndexes.split("\\s+"));
+
         Set<Index> indexes;
         try {
             indexes = ParserUtil.parseIndexes(oneBasedIndexStrings);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -35,6 +35,13 @@ public class ParserUtil {
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
+    /**
+     * Parses the collection of raw one-based indexes into a set of indexes and returns it.
+     * Individual elements will be parsed using {@link ParserUtil#parseIndex}.
+     *
+     * @param oneBasedIndexes The collection of one-based indexes to be parsed.
+     * @throws ParseException If the specified index is invalid (as specified by {@link ParserUtil#parseIndex}.
+     */
     public static Set<Index> parseIndexes(Collection<String> oneBasedIndexes) throws ParseException {
         requireNonNull(oneBasedIndexes);
         final Set<Index> indexSet = new HashSet<>();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -35,6 +35,15 @@ public class ParserUtil {
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
+    public static Set<Index> parseIndexes(Collection<String> oneBasedIndexes) throws ParseException {
+        requireNonNull(oneBasedIndexes);
+        final Set<Index> indexSet = new HashSet<>();
+        for (String oneBasedIndex : oneBasedIndexes) {
+            indexSet.add(parseIndex(oneBasedIndex));
+        }
+        return indexSet;
+    }
+
     /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,11 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -75,6 +79,37 @@ public class DeleteCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexesFilteredList_success() {
+
+        Person firstPersonToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPersonToDelete = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(
+                Set.of(INDEX_FIRST_PERSON, INDEX_THIRD_PERSON));
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(List.of(firstPersonToDelete, secondPersonToDelete)));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(firstPersonToDelete);
+        expectedModel.deletePerson(secondPersonToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexesFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(Set.of(INDEX_FIRST_PERSON, outOfBoundIndex));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -32,7 +32,7 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "m/123", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "i/123", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -40,25 +40,25 @@ public class DeleteCommandParserTest {
         DeleteCommand expectedCommand = new DeleteCommand(
                 Set.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON));
 
-        assertParseSuccess(parser, " m/1 2 3", expectedCommand);
-        assertParseSuccess(parser, " m/ 1 2 3  ", expectedCommand);
-        assertParseSuccess(parser, " m/1-3 ", expectedCommand);
-        assertParseSuccess(parser, " m/3 ", new DeleteCommand(INDEX_THIRD_PERSON));
+        assertParseSuccess(parser, " i/1 2 3", expectedCommand);
+        assertParseSuccess(parser, " i/ 1 2 3  ", expectedCommand);
+        assertParseSuccess(parser, " i/1-3 ", expectedCommand);
+        assertParseSuccess(parser, " i/3 ", new DeleteCommand(INDEX_THIRD_PERSON));
     }
 
     @Test
     public void parse_invalidMassOpsArgs_throwsException() {
-        assertParseFailure(parser, " m/12- 2 3 4",
+        assertParseFailure(parser, " i/12- 2 3 4",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, " m/1-3-4",
+        assertParseFailure(parser, " i/1-3-4",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, " m/1-3 4",
+        assertParseFailure(parser, " i/1-3 4",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, " m/1-3 4-5",
+        assertParseFailure(parser, " i/1-3 4-5",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
 
         // out-of-range index
-        assertParseFailure(parser, " m/1243474758943-234875783495789345",
+        assertParseFailure(parser, " i/1243474758943-234875783495789345",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -4,6 +4,10 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,5 +32,33 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "m/123", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validMassOpsArgs_returnsDeleteCommand() {
+        DeleteCommand expectedCommand = new DeleteCommand(
+                Set.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON));
+
+        assertParseSuccess(parser, " m/1 2 3", expectedCommand);
+        assertParseSuccess(parser, " m/ 1 2 3  ", expectedCommand);
+        assertParseSuccess(parser, " m/1-3 ", expectedCommand);
+        assertParseSuccess(parser, " m/3 ", new DeleteCommand(INDEX_THIRD_PERSON));
+    }
+
+    @Test
+    public void parse_invalidMassOpsArgs_throwsException() {
+        assertParseFailure(parser, " m/12- 2 3 4",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " m/1-3-4",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " m/1-3 4",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " m/1-3 4-5",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // out-of-range index
+        assertParseFailure(parser, " m/1243474758943-234875783495789345",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/MassOpsIndexParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MassOpsIndexParserTest.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.parser;
+
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class MassOpsIndexParserTest {
+    private MassOpsIndexParser massOpsIndexParser;
+    private final Set<Index> tripleIndexes = Set.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON);
+    private final Set<Index> doubleIndexes = Set.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+    private final String singleIndexString = "12345";
+    private final Set<Index> singleIndex = Set.of(Index.fromOneBased(Integer.parseInt(singleIndexString)));
+
+    @BeforeEach
+    public void setUp() {
+        massOpsIndexParser = new MassOpsIndexParser();
+    }
+    @Test
+    public void parseIndexes_validSpacePattern_success() {
+        assertDoesNotThrow(() -> tripleIndexes.equals(massOpsIndexParser.parseIndexes("1 2 3")));
+        assertDoesNotThrow(() -> tripleIndexes.equals(massOpsIndexParser.parseIndexes(" 1 2  3")));
+        assertDoesNotThrow(() -> doubleIndexes.equals(massOpsIndexParser.parseIndexes("1   2 ")));
+        assertDoesNotThrow(() -> doubleIndexes.equals(massOpsIndexParser.parseIndexes("   1   2 ")));
+        assertDoesNotThrow(() -> singleIndex.equals(massOpsIndexParser.parseIndexes(singleIndexString)));
+    }
+
+    @Test
+    public void parseIndexes_invalidSpacePattern_exceptionThrown() {
+        ParseException pe = assertThrows(ParseException.class, () -> massOpsIndexParser.parseIndexes("1    123oi"));
+        assertEquals(MassOpsIndexParser.MESSAGE_INVALID_INDEX, pe.getMessage());
+    }
+
+    @Test
+    public void parseIndexes_overflowingIndex_exceptionThrown() {
+        ParseException pe = assertThrows(
+                ParseException.class, () -> massOpsIndexParser.parseIndexes("18327234238349853457834975"));
+        assertEquals(MassOpsIndexParser.MESSAGE_INVALID_INDEX, pe.getMessage());
+
+        ParseException pe1 = assertThrows(
+                ParseException.class, () -> massOpsIndexParser.parseIndexes("1293889123-124823723857349852378329747"));
+        assertEquals(MassOpsIndexParser.MESSAGE_INVALID_INDEX, pe1.getMessage());
+    }
+
+    @Test
+    public void parseIndexes_validRangePattern_success() {
+        assertDoesNotThrow(() -> tripleIndexes.equals(massOpsIndexParser.parseIndexes("1-3")));
+        assertDoesNotThrow(() -> tripleIndexes.equals(massOpsIndexParser.parseIndexes(" 1 - 3 ")));
+        assertDoesNotThrow(() -> doubleIndexes.equals(massOpsIndexParser.parseIndexes("1-2")));
+        assertDoesNotThrow(() -> doubleIndexes.equals(massOpsIndexParser.parseIndexes(" 1 -     2 ")));
+        assertDoesNotThrow(() -> singleIndex.equals(massOpsIndexParser.parseIndexes("12345-12345")));
+    }
+
+    @Test
+    public void parseIndexes_invalidRangePattern_exceptionThrown() {
+        ParseException pe = assertThrows(ParseException.class, () -> massOpsIndexParser.parseIndexes("1- 123oi"));
+        assertEquals(MassOpsIndexParser.MESSAGE_INVALID_INDEX, pe.getMessage());
+    }
+
+    @Test
+    public void parseIndexes_rangeExceedsLimit_exceptionThrown() {
+        ParseException pe = assertThrows(ParseException.class, () -> massOpsIndexParser.parseIndexes("1-101"));
+        assertEquals(MassOpsIndexParser.MESSAGE_RANGE_SIZE_EXCEEDED, pe.getMessage());
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 1; i <= MassOpsIndexParser.MAX_OPERATIONS_SIZE + 1; i++) {
+            builder.append(" ").append(i);
+        }
+        ParseException pe1 = assertThrows(
+                ParseException.class, () -> massOpsIndexParser.parseIndexes(builder.toString()));
+        assertEquals(MassOpsIndexParser.MESSAGE_RANGE_SIZE_EXCEEDED, pe1.getMessage());
+    }
+
+    @Test
+    public void parseIndexes_invalidRangeBoundOrder_exceptionThrown() {
+        ParseException pe = assertThrows(ParseException.class, () -> massOpsIndexParser.parseIndexes("100-2"));
+        assertEquals(MassOpsIndexParser.MESSAGE_INVALID_RANGE_ORDER, pe.getMessage());
+    }
+
+
+}


### PR DESCRIPTION
Closes #82 

Adds support for the following operations:
- `delete i/123 1 2 3 5` (spaced 1-based indexes)
- `delete i/2-5` (range 1-based indexes)

Some notes:
- Allows performing operations up to 100 indexes
- Multiple `i/` prefixes in delete is not allowed
- Specifying duplicate indexes will be treated as-if there were no duplicates