### PR TITLE
Fix: Person details UI not updating as intended

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -211,6 +211,9 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            // clears the person details since the list may have changed
+            personDetailPlaceholder.getChildren().clear();
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);


### PR DESCRIPTION
Closes #107 

Similarly bugged behaviour can be discovered with deleting and deleting multiple/all elements
One example is deleting all client contacts in the client contacts list will still show the previous person's details

Simple fix:
Whenever a command is executed, the person details in the UI are cleared

